### PR TITLE
fix: cors issue

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,8 +15,9 @@ const PORT = process.env.PORT || 5000;
 app.use(
   cors({
     origin: process.env.REACT_APP_CLIENT_URL,
-    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     credentials: true,
+    preflightContinue: false,
+    optionsSuccessStatus: 200
   })
 );
 

--- a/server/index.js
+++ b/server/index.js
@@ -16,7 +16,6 @@ app.use(
   cors({
     origin: process.env.REACT_APP_CLIENT_URL,
     credentials: true,
-    preflightContinue: false,
     optionsSuccessStatus: 200
   })
 );


### PR DESCRIPTION
## Changes
- `methods`: default values are `GET,HEAD,PUT,PATCH,POST,DELETE`, enough for most of the cases, no need to override.
- `optionsSuccessStatus`: Provides a status code to use for successful OPTIONS requests, since some legacy browsers (IE11, various SmartTVs) choke on 204. So set it to `200`
- For `origin` in `cors` configuration object: The origin should be specified without a trailing slash. The correct format is 'http://localhost:3000'